### PR TITLE
Restore _POSIX_C_SOURCE define

### DIFF
--- a/tinyfiledialogs.c
+++ b/tinyfiledialogs.c
@@ -48,6 +48,13 @@ Thanks for contributions, bug corrections & thorough testing to:
 - Jory Folker
 */
 
+
+#ifndef __sun
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 2 /* to accept POSIX 2 in old ANSI C standards */
+#endif
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
This was removed in commit 3d09833d9b094031f7b04e93871ed20729fe60f4, but is needed to use `popen()` when building with glibc.